### PR TITLE
Update ForceDropTable Usage

### DIFF
--- a/sql-reference/sql-statements/data-definition/DROP TABLE.md
+++ b/sql-reference/sql-statements/data-definition/DROP TABLE.md
@@ -7,7 +7,7 @@ This statement is used to delete a table.
 Syntax:
 
 ```sql
-DROP TABLE [IF EXISTS] [FORCE] [db_name.]table_name ;
+DROP TABLE [IF EXISTS] [db_name.]table_name [FORCE];
 ```
 
 Note:
@@ -27,6 +27,12 @@ Note:
 
     ```sql
     DROP TABLE IF EXISTS example_db.my_table;
+    ```
+
+3. Force to drop the table and clear its data on disk.
+
+    ```sql
+    DROP TABLE my_table FORCE;
     ```
 
 ## keyword


### PR DESCRIPTION
Now the usge of `Drop Table Force` in doc page has some error as below:
![9607111c1332f537d0caaa905d4670a](https://user-images.githubusercontent.com/7404824/149535628-95e6959c-fb13-4239-bced-ae9957168b5b.jpg)

The correct usage is this:

![7e00351efc5b94f86816f0ac62e68c9](https://user-images.githubusercontent.com/7404824/149535693-dfda508b-37f6-4aa0-aa86-cfe9ad244018.jpg)
