### PR TITLE
Fixing java path in Dockerfile and run_script.sh

### DIFF
--- a/quick_start/Deploy.md
+++ b/quick_start/Deploy.md
@@ -437,7 +437,7 @@ RUN cd /data/deploy/ && tar zxf StarRocks-x.x.x.tar.gz
 # Install Java JDK.
 RUN yum -y install java-1.8.0-openjdk-devel.x86_64
 RUN rpm -ql java-1.8.0-openjdk-devel.x86_64 | grep bin$
-RUN /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b09-1.el7_9.x86_64/bin/java -version
+RUN /usr/lib/jvm/java-1.8.0/bin/java -version
 
 # Create directory for FE meta and BE storage in StarRocks.
 RUN mkdir -p /data/deploy/StarRocks-x.x.x/fe/meta
@@ -465,7 +465,7 @@ build the script file `run_script.sh` to configure and start StarRocks.
 #!/bin/bash
 
 # Set JAVA_HOME.
-export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64
+export JAVA_HOME=/usr/lib/jvm/java-1.8.0
 
 # Start FE.
 cd /data/deploy/StarRocks-x.x.x/fe/bin/


### PR DESCRIPTION
This updates the `JAVA_HOME` paths in the docker example to use the symlink `/usr/lib/jvm/java-1.8.0/bin/java`, otherwise this is currently breaking when the directory name changes for new jdk releases.